### PR TITLE
Fixed bad substitution

### DIFF
--- a/libretranslate.sh
+++ b/libretranslate.sh
@@ -9,7 +9,7 @@ fi
 
 if [ $LIBRETRANSLATE_API_KEY ]
 then
-    api_key_flag="-F \"api_key=${$LIBRETRANSLATE_API_KEY}\""
+    api_key_flag="-F \"api_key=${LIBRETRANSLATE_API_KEY}\""
 else
     api_key_flag=""
 fi


### PR DESCRIPTION
I got: 

```sh
libretranslate.sh: line 12: -F "api_key=${$LIBRETRANSLATE_API_KEY}": bad substitution
```

Removing the second `$` seems to be the fix.  